### PR TITLE
Add getInvoicesByCustomer method

### DIFF
--- a/src/Traits/ManagesInvoices.php
+++ b/src/Traits/ManagesInvoices.php
@@ -44,6 +44,43 @@ trait ManagesInvoices
         return $this->getNodes();
     }
 
+    public function getInvoicesByCustomer(string $customerId, ?array $variables = []): Collection
+    {
+        $variables['customerId'] = $customerId;
+
+        if (! isset($variables['sort'])) {
+            $variables['sort'] = InvoiceSort::INVOICE_DATE_ASC;
+        }
+        // Merge with cached variables.
+        $variables = array_merge($this->cachedVariables, $variables);
+        // Save new cached variables.
+        $this->cachedVariables = $variables;
+
+        $businessId = $this->getBusinessId();
+        $pageInfoNode = QueryObject::pageInfo();
+        $invoiceNode = QueryObject::invoice();
+
+        $this->cachedQuery = <<<GQL
+            query(\$customerId: ID!, \$page: Int, \$pageSize: Int, \$sort: [InvoiceSort!]!, \$modifiedAtAfter: DateTime, \$modifiedAtBefore: DateTime) {
+                business(id: "{$businessId}") {
+                    invoices(customerId: \$customerId, page: \$page, pageSize: \$pageSize, sort: \$sort, modifiedAtAfter: \$modifiedAtAfter, modifiedAtBefore: \$modifiedAtBefore) {
+                        pageInfo {
+                            $pageInfoNode
+                        }
+                        edges {
+                            node {
+                                $invoiceNode
+                            }
+                        }
+                    }
+                }
+            }
+            GQL;
+        $this->cachedResponse = $this->query($variables);
+
+        return $this->getNodes();
+    }
+
     public function getAllInvoices(?array $variables = []): Collection
     {
         $variables['page'] = 1;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a new GraphQL query wrapper method without changing existing invoice retrieval or mutation behavior.
> 
> **Overview**
> Adds `getInvoicesByCustomer($customerId, $variables)` to `ManagesInvoices`, enabling invoice retrieval scoped to a specific customer via the GraphQL `invoices(customerId: ...)` query.
> 
> The new method mirrors `getInvoices` behavior (default sort, pagination/modification filters, cached variables/query/response) while requiring a `customerId` variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd2762a78badfb710945642520374a8c01f11df3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->