### PR TITLE
Update composer dependencies for Laravel 11, 12, and 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,9 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": ">=6.0",
-        "laravel/framework": ">=9.0"
+        "php": "^8.2",
+        "guzzlehttp/guzzle": "^7.0",
+        "laravel/framework": "^11.0|^12.0|^13.0"
     },
     "autoload-dev": {
         "psr-4": {
@@ -35,7 +36,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.3",
-        "orchestra/testbench": "~3.0"
+        "phpunit/phpunit": "^10.5|^11.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0"
     }
 }


### PR DESCRIPTION
## Summary

- Added `php ^8.2` requirement (minimum for Laravel 11+)
- Updated `laravel/framework` from `>=9.0` to `^11.0|^12.0|^13.0`
- Updated `guzzlehttp/guzzle` from `>=6.0` to `^7.0` (required by Laravel 11+)
- Updated `phpunit/phpunit` from `^8.3` to `^10.5|^11.0`
- Updated `orchestra/testbench` from `~3.0` to `^9.0|^10.0|^11.0` (v9=L11, v10=L12, v11=L13)

## Why

The previous dependency constraints were outdated and would fail to install on Laravel 11+ projects due to incompatible dev dependencies. This update ensures the package works with Laravel 11, 12, and 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)