### PR TITLE
Expand PHPUnit version constraint to include v12 and v13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5|^11.0",
+        "phpunit/phpunit": "^10.5|^11.0|^12.0|^13.0",
         "orchestra/testbench": "^9.0|^10.0|^11.0"
     }
 }


### PR DESCRIPTION
## Summary

- Updates the `phpunit/phpunit` dev dependency constraint from `^10.5|^11.0` to `^10.5|^11.0|^12.0|^13.0`
- PHPUnit 12 and 13 have been released since the current constraint was written (latest is 13.1.11)
- Expanding the constraint prevents consumers of this package from hitting version conflicts when using newer PHPUnit versions

## Test plan

- [ ] Verify `composer install` resolves without errors on PHPUnit 10, 11, 12, and 13
- [ ] Confirm existing test suite passes under each supported PHPUnit version

https://claude.ai/code/session_011LFCoGeDLTYcpfE2hTgacv

---
_Generated by [Claude Code](https://claude.ai/code/session_011LFCoGeDLTYcpfE2hTgacv)_